### PR TITLE
fix sqlite version detect

### DIFF
--- a/autoload/todoapp.vim
+++ b/autoload/todoapp.vim
@@ -2,10 +2,10 @@ let s:save_cpo = &cpo
 set cpo&vim
 let s:file = expand('~').'/.todo/todo.sqlite'
 
-if executable('sqlite')
-  let s:sqlite = 'sqlite'
-elseif executable('sqlite3')
+if executable('sqlite3')
   let s:sqlite = 'sqlite3'
+elseif executable('sqlite')
+  let s:sqlite = 'sqlite'
 endif
 
 function! todoapp#add(content)


### PR DESCRIPTION
Ubuntu 18.04.2 LTS 中
```
sudo apt install sqlite
```
会安装 `sqlite` 和 `sqlite3`
```
$ sqlite -version        
2.8.17

$ sqlite3 -version                                                                                                                        1 ↵
3.22.0 2018-01-22 18:45:57 0c55d179733b46d8d0ba4d88e01a25e10677046ee3da1d5b1581e86726f2alt1
```
`sqlite` 默认执行2.8版本，貌似不兼容下面这里的 sql 命令，所以会报错 `SQL error: near "NOT": syntax error
`
https://github.com/neoclide/todoapp.vim/blob/b1e7302ca5b1a06828ddb20aabae7150a26174ff/autoload/todoapp.vim#L13

所以感觉先检测版本 `sqlite3` 会好一点这样子
